### PR TITLE
Update QuizService.java

### DIFF
--- a/quizApp/src/main/java/com/maxx/quizApp/service/QuizService.java
+++ b/quizApp/src/main/java/com/maxx/quizApp/service/QuizService.java
@@ -54,13 +54,22 @@ public class QuizService {
         List<Question> questions = quiz.getQuestions();
 
         int right =0;
-        int i= 0;
-        for(Response response : responses){
-            if(response.getResponse().equals(questions.get(i).getRightAnswer()))
-                right++;
+         int i= 0;
+        
+       Map<Integer, Question> questionMap = new HashMap<>();
+	    for (Question question : questions) {
+	        questionMap.put(question.getId(), question);
+	    }
 
-            i++;
-        }
+	    // Iterate through the responses
+	    for (Response response : responses) {
+	        // Retrieve the corresponding question using the response's question ID
+	        Question question = questionMap.get(response.getId());
+	        if (question != null && response.getResponse().equals(question.getRightAnswer())) {
+	            right++; // Increment the correct response count
+	        }
+	    }
+
         return new ResponseEntity<>(right,HttpStatus.OK);
     }
 }


### PR DESCRIPTION
Update QuizService.java
Changed calculateResult method to calculate result in quizService.

Previous method only worked if response list and questions list were in same order. What if response is suffled or list of questions fetched from database is not in order of respose then there answers wont match as we are matching them with index not by id.

Created a HashMap to store key as 'id' and value as 'question' object and store all questions in Map.

Now it became easy to fetch question by "response.getId" and compared both answers.